### PR TITLE
return non-zero exit code on resolving failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ The package name takes the Maven format: `<groupId>:<artifactId>:<version>`
 
 There's also a few flags available:
 ```
-Usage of go-maven-resolver:
+Usage of ./go-maven-resolver:
+  -exitCode
+    	Set exit code on any resolving failures. (default true)
+  -ignoreOptional
+    	Ignore optional dependencies. (default true)
   -ignoreScopes string
     	Scopes to ignore. (default "provided,system,test")
   -recursive
     	Should recursive resolution be done (default true)
   -reposFile string
     	Path file with repo URLs to check.
+  -retries int
+    	HTTP request retries on non-404 codes. (default 2)
   -timeout int
     	HTTP request timeout in seconds. (default 2)
   -workers int

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -17,6 +17,7 @@ type Options struct {
 }
 
 type Finder struct {
+	failed   bool            /* set to true if any requests failed */
 	opts     Options         /* options for handling dependencies */
 	fetchers fetcher.Fetcher /* pool of workers for HTTP requests */
 	l        *log.Logger     /* for logging events */
@@ -109,6 +110,7 @@ func (f *Finder) FindUrls(dep pom.Dependency) {
 	url, project, err := f.ResolveDep(dep)
 	if err != nil {
 		f.l.Printf("error: '%s' for: %s", err, dep)
+		f.failed = true
 		return
 	}
 
@@ -116,6 +118,7 @@ func (f *Finder) FindUrls(dep pom.Dependency) {
 	 * fails it is due to an HTTP error or XML parsing error. */
 	if url == "" {
 		f.l.Printf("error: 'no URL found' for: %s", dep)
+		f.failed = true
 		return
 	}
 
@@ -142,4 +145,8 @@ func (f *Finder) Resolve(dep pom.Dependency) {
 
 func (f *Finder) Wait() {
 	f.wg.Wait()
+}
+
+func (f *Finder) Failed() bool {
+	return f.failed
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	ignoreScopes   string
 	ignoreOptional bool
 	recursive      bool
+	exitCode       bool
 )
 
 const helpMessage string = `
@@ -52,6 +53,7 @@ func flagsInit() {
 	flag.StringVar(&reposFile, "reposFile", "", "Path file with repo URLs to check.")
 	flag.StringVar(&ignoreScopes, "ignoreScopes", "provided,system,test", "Scopes to ignore.")
 	flag.BoolVar(&ignoreOptional, "ignoreOptional", true, "Ignore optional dependencies.")
+	flag.BoolVar(&exitCode, "exitCode", true, "Set exit code on any resolving failures.")
 	flag.Parse()
 }
 
@@ -106,4 +108,9 @@ func main() {
 	/* Each FindUrls() call can spawn more recursive FindUrls() routines.
 	 * To know when to stop the process they also increment the WaitGroup. */
 	fnr.Wait()
+
+	/* If any of the requests failed return a non-0 exit code */
+	if exitCode && fnr.Failed() {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
People ignore errors in console like:
```
finder.go:91: error: 'no pom data' for: <Dep ID=com.afollestad.material-dialogs:commons:0.9.6.0 O=false S= >
```
If the program doesn't outright fail.

And yes, I know I'm not protecting `failed` variable from race conditions, but there aren't any, since the only operation is setting it to `true` from the default `false`.