### PR TITLE
fix handling of transitive dependencies

### DIFF
--- a/finder/finder.go
+++ b/finder/finder.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Options struct {
-	IgnoreScopes    []string /* list of dependency scopes to ignore */
-	IgnoreOptional  bool     /* if optional dependencies should be ignored */
-	RecursiveSearch bool     /* recursive dependency resolution switch */
+	IgnoreScopes     []string /* list of dependency scopes to ignore */
+	IgnoreOptional   bool     /* if optional dependencies should be ignored */
+	IgnoreTransitive bool     /* managed dependencies can be often ignored  */
+	RecursiveSearch  bool     /* recursive dependency resolution switch */
 }
 
 type Finder struct {
@@ -76,6 +77,14 @@ func (f *Finder) ResolveDep(dep pom.Dependency) (string, *pom.Project, error) {
 }
 
 func (f *Finder) InvalidDep(dep pom.Dependency) bool {
+	if dep.Transitive {
+		if f.opts.IgnoreTransitive {
+			return true
+		} else if dep.Scope == "none" {
+			/* Unscoped transitive deps are mostly useless trash. */
+			return true
+		}
+	}
 	/* Check if the scope matches any of the ignored ones. */
 	for i := range f.opts.IgnoreScopes {
 		if dep.Scope == f.opts.IgnoreScopes[i] {

--- a/main.go
+++ b/main.go
@@ -15,14 +15,15 @@ import (
 var l *log.Logger
 
 var (
-	workersNum     int
-	requestRetries int
-	requestTimeout int
-	reposFile      string
-	ignoreScopes   string
-	ignoreOptional bool
-	recursive      bool
-	exitCode       bool
+	workersNum       int
+	requestRetries   int
+	requestTimeout   int
+	reposFile        string
+	ignoreScopes     string
+	ignoreOptional   bool
+	ignoreTransitive bool
+	recursive        bool
+	exitCode         bool
 )
 
 const helpMessage string = `
@@ -53,6 +54,7 @@ func flagsInit() {
 	flag.StringVar(&reposFile, "reposFile", "", "Path file with repo URLs to check.")
 	flag.StringVar(&ignoreScopes, "ignoreScopes", "provided,system,test", "Scopes to ignore.")
 	flag.BoolVar(&ignoreOptional, "ignoreOptional", true, "Ignore optional dependencies.")
+	flag.BoolVar(&ignoreTransitive, "ignoreTransitive", false, "Ignore transitive dependencies.")
 	flag.BoolVar(&exitCode, "exitCode", true, "Set exit code on any resolving failures.")
 	flag.Parse()
 }
@@ -75,9 +77,10 @@ func main() {
 
 	/* Controls which dependencies are resolved. */
 	finderOpts := finder.Options{
-		IgnoreScopes:    strings.Split(ignoreScopes, ","),
-		IgnoreOptional:  ignoreOptional,
-		RecursiveSearch: recursive,
+		IgnoreScopes:     strings.Split(ignoreScopes, ","),
+		IgnoreOptional:   ignoreOptional,
+		IgnoreTransitive: ignoreTransitive,
+		RecursiveSearch:  recursive,
 	}
 
 	/* A separate pool of fetcher workers prevents running out of sockets */

--- a/pom/dependency.go
+++ b/pom/dependency.go
@@ -13,6 +13,8 @@ type Dependency struct {
 	Version    string `xml:"version"`
 	Scope      string `xml:"scope"`
 	Optional   bool   `xml:"optional"`
+	/* Indirect dependencies */
+	Transitive bool
 }
 
 /* Maven uses a special format for dependency identifiers:
@@ -39,6 +41,9 @@ func (d Dependency) FixFields(parent Project) Dependency {
 	}
 	if d.Version == "${project.version}" {
 		d.Version = parent.Version
+	}
+	if d.Scope == "" {
+		d.Scope = "none"
 	}
 	return d
 }

--- a/pom/project.go
+++ b/pom/project.go
@@ -8,13 +8,14 @@ import (
 
 /* Root object in XML POM files defining packages. */
 type Project struct {
-	GroupId      string       `xml:"groupId"`
-	ArtifactId   string       `xml:"artifactId"`
-	Name         string       `xml:"name"`
-	Version      string       `xml:"version"`
-	Parent       Dependency   `xml:"parent"`
-	Dependencies []Dependency `xml:"dependencies>dependency"`
-	Build        struct {
+	GroupId         string       `xml:"groupId"`
+	ArtifactId      string       `xml:"artifactId"`
+	Name            string       `xml:"name"`
+	Version         string       `xml:"version"`
+	Parent          Dependency   `xml:"parent"`
+	Dependencies    []Dependency `xml:"dependencies>dependency"`
+	DependenciesMgm []Dependency `xml:"dependencyManagement>dependencies>dependency"`
+	Build           struct {
 		Plugins []Dependency `xml:"plugins>plugin"`
 	}
 }
@@ -49,6 +50,10 @@ func (p Project) GetDependencies() []Dependency {
 		deps = append(deps, p.Parent)
 	}
 	for _, dep := range p.Dependencies {
+		deps = append(deps, dep.FixFields(p))
+	}
+	for _, dep := range p.DependenciesMgm {
+		dep.Transitive = true
 		deps = append(deps, dep.FixFields(p))
 	}
 	for _, dep := range p.Build.Plugins {


### PR DESCRIPTION
This fixes issue with missing dependencies like:
```
> Could not find com.google.protobuf:protobuf-bom:3.10.0.
```
Which was not reported for `com.google.protobuf:protobuf-java:3.10.0`.

This is necessary for Gradle 6+, but for now I'm leaving this disabled.

It's not enough to track `dependencies` field. We also need to scan the `dependencyManagement` field for transitive dependencies. Most of them are in `test` scope or without a scope, but some like `import` are needed.

Dependency Management allows to consolidate and centralize the management of dep. versions without adding deps which are inherited by all children. Useful when you have a set of projects that inherits a common parent.

For more details see:
- https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management

Signed-off-by: Jakub Sokołowski <jakub@status.im>