### PR TITLE
Fixed parsing XML files that contain html entities

### DIFF
--- a/pom/metadata.go
+++ b/pom/metadata.go
@@ -30,6 +30,7 @@ func MetadataFromReader(reader io.ReadCloser) (meta *Metadata, err error) {
 	}()
 	decoder := xml.NewDecoder(reader)
 	decoder.CharsetReader = charset.NewReaderLabel
+	decoder.Entity = xml.HTMLEntity
 	err = decoder.Decode(&meta)
 	return
 }

--- a/pom/project.go
+++ b/pom/project.go
@@ -30,6 +30,7 @@ func ProjectFromReader(reader io.ReadCloser) (project *Project, err error) {
 	}()
 	decoder := xml.NewDecoder(reader)
 	decoder.CharsetReader = charset.NewReaderLabel
+	decoder.Entity = xml.HTMLEntity
 	err = decoder.Decode(&project)
 	return
 }


### PR DESCRIPTION
This PR fixes parsing XML files  that contain HTML entities. Some packages may contain HTML entities (for special symbol in names, etc.), and currently they are not handled properly. 

For example, `echo org.codehaus.plexus:plexus:1.0.4 | go-maven-resolver` doesn't work without this change.

By the way, it would be nice if this repo could have enabled issues as they seem to be disabled :sweat_smile: